### PR TITLE
Arreglo de trepado de ciego, subir escalera y moviemientos extraños de la camara

### DIFF
--- a/Assets/Animators/Blind/Blind .controller
+++ b/Assets/Animators/Blind/Blind .controller
@@ -15,6 +15,9 @@ AnimatorStateMachine:
   - serializedVersion: 1
     m_State: {fileID: 5713503536389025138}
     m_Position: {x: 330, y: 180, z: 0}
+  - serializedVersion: 1
+    m_State: {fileID: 1454199848312529041}
+    m_Position: {x: 570, y: 200, z: 0}
   m_ChildStateMachines: []
   m_AnyStateTransitions: []
   m_EntryTransitions: []
@@ -25,6 +28,31 @@ AnimatorStateMachine:
   m_ExitPosition: {x: 800, y: 120, z: 0}
   m_ParentStateMachinePosition: {x: 800, y: 20, z: 0}
   m_DefaultState: {fileID: 5713503536389025138}
+--- !u!1101 &-972200928906961402
+AnimatorStateTransition:
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: 
+  m_Conditions:
+  - m_ConditionMode: 1
+    m_ConditionEvent: LadderClimbing
+    m_EventTreshold: 0
+  m_DstStateMachine: {fileID: 0}
+  m_DstState: {fileID: 1454199848312529041}
+  m_Solo: 0
+  m_Mute: 0
+  m_IsExit: 0
+  serializedVersion: 3
+  m_TransitionDuration: 0
+  m_TransitionOffset: 0
+  m_ExitTime: 0.97159433
+  m_HasExitTime: 0
+  m_HasFixedDuration: 1
+  m_InterruptionSource: 0
+  m_OrderedInterruption: 1
+  m_CanTransitionToSelf: 1
 --- !u!91 &9100000
 AnimatorController:
   m_ObjectHideFlags: 0
@@ -35,6 +63,12 @@ AnimatorController:
   serializedVersion: 5
   m_AnimatorParameters:
   - m_Name: Running
+    m_Type: 4
+    m_DefaultFloat: 0
+    m_DefaultInt: 0
+    m_DefaultBool: 0
+    m_Controller: {fileID: 0}
+  - m_Name: LadderClimbing
     m_Type: 4
     m_DefaultFloat: 0
     m_DefaultInt: 0
@@ -78,6 +112,58 @@ AnimatorStateTransition:
   m_InterruptionSource: 0
   m_OrderedInterruption: 1
   m_CanTransitionToSelf: 1
+--- !u!1102 &1454199848312529041
+AnimatorState:
+  serializedVersion: 6
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: climb
+  m_Speed: 1
+  m_CycleOffset: 0
+  m_Transitions:
+  - {fileID: 5527005671177216423}
+  m_StateMachineBehaviours: []
+  m_Position: {x: 50, y: 50, z: 0}
+  m_IKOnFeet: 0
+  m_WriteDefaultValues: 1
+  m_Mirror: 0
+  m_SpeedParameterActive: 0
+  m_MirrorParameterActive: 0
+  m_CycleOffsetParameterActive: 0
+  m_TimeParameterActive: 0
+  m_Motion: {fileID: 7400000, guid: 77eecb926bd06da4a83ca3b9583b6b33, type: 2}
+  m_Tag: 
+  m_SpeedParameter: 
+  m_MirrorParameter: 
+  m_CycleOffsetParameter: 
+  m_TimeParameter: 
+--- !u!1101 &5527005671177216423
+AnimatorStateTransition:
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: 
+  m_Conditions:
+  - m_ConditionMode: 2
+    m_ConditionEvent: LadderClimbing
+    m_EventTreshold: 0
+  m_DstStateMachine: {fileID: 0}
+  m_DstState: {fileID: 5713503536389025138}
+  m_Solo: 0
+  m_Mute: 0
+  m_IsExit: 0
+  serializedVersion: 3
+  m_TransitionDuration: 0
+  m_TransitionOffset: 0
+  m_ExitTime: 0.9925791
+  m_HasExitTime: 0
+  m_HasFixedDuration: 1
+  m_InterruptionSource: 0
+  m_OrderedInterruption: 1
+  m_CanTransitionToSelf: 1
 --- !u!1102 &5713503536389025138
 AnimatorState:
   serializedVersion: 6
@@ -90,6 +176,7 @@ AnimatorState:
   m_CycleOffset: 0
   m_Transitions:
   - {fileID: 8712696246729990414}
+  - {fileID: -972200928906961402}
   m_StateMachineBehaviours: []
   m_Position: {x: 50, y: 50, z: 0}
   m_IKOnFeet: 0

--- a/Assets/Animators/Blind/climb.anim
+++ b/Assets/Animators/Blind/climb.anim
@@ -17,15 +17,54 @@ AnimationClip:
   m_PositionCurves: []
   m_ScaleCurves: []
   m_FloatCurves: []
-  m_PPtrCurves: []
+  m_PPtrCurves:
+  - curve:
+    - time: 0
+      value: {fileID: -1163522440, guid: 249ac06a84bfe9445bae534cc59a26b7, type: 3}
+    - time: 0.1
+      value: {fileID: 871637124, guid: 249ac06a84bfe9445bae534cc59a26b7, type: 3}
+    - time: 0.21666667
+      value: {fileID: 350730551, guid: 249ac06a84bfe9445bae534cc59a26b7, type: 3}
+    - time: 0.35
+      value: {fileID: -162602001, guid: 249ac06a84bfe9445bae534cc59a26b7, type: 3}
+    - time: 0.48333332
+      value: {fileID: -1265435967, guid: 249ac06a84bfe9445bae534cc59a26b7, type: 3}
+    - time: 0.6
+      value: {fileID: 823045997, guid: 249ac06a84bfe9445bae534cc59a26b7, type: 3}
+    - time: 0.73333335
+      value: {fileID: -820606024, guid: 249ac06a84bfe9445bae534cc59a26b7, type: 3}
+    - time: 0.85
+      value: {fileID: -1594431279, guid: 249ac06a84bfe9445bae534cc59a26b7, type: 3}
+    - time: 0.98333335
+      value: {fileID: -1594431279, guid: 249ac06a84bfe9445bae534cc59a26b7, type: 3}
+    attribute: m_Sprite
+    path: Sprite
+    classID: 212
+    script: {fileID: 0}
   m_SampleRate: 60
   m_WrapMode: 0
   m_Bounds:
     m_Center: {x: 0, y: 0, z: 0}
     m_Extent: {x: 0, y: 0, z: 0}
   m_ClipBindingConstant:
-    genericBindings: []
-    pptrCurveMapping: []
+    genericBindings:
+    - serializedVersion: 2
+      path: 850496168
+      attribute: 0
+      script: {fileID: 0}
+      typeID: 212
+      customType: 23
+      isPPtrCurve: 1
+    pptrCurveMapping:
+    - {fileID: -1163522440, guid: 249ac06a84bfe9445bae534cc59a26b7, type: 3}
+    - {fileID: 871637124, guid: 249ac06a84bfe9445bae534cc59a26b7, type: 3}
+    - {fileID: 350730551, guid: 249ac06a84bfe9445bae534cc59a26b7, type: 3}
+    - {fileID: -162602001, guid: 249ac06a84bfe9445bae534cc59a26b7, type: 3}
+    - {fileID: -1265435967, guid: 249ac06a84bfe9445bae534cc59a26b7, type: 3}
+    - {fileID: 823045997, guid: 249ac06a84bfe9445bae534cc59a26b7, type: 3}
+    - {fileID: -820606024, guid: 249ac06a84bfe9445bae534cc59a26b7, type: 3}
+    - {fileID: -1594431279, guid: 249ac06a84bfe9445bae534cc59a26b7, type: 3}
+    - {fileID: -1594431279, guid: 249ac06a84bfe9445bae534cc59a26b7, type: 3}
   m_AnimationClipSettings:
     serializedVersion: 2
     m_AdditiveReferencePoseClip: {fileID: 0}

--- a/Assets/Prefabs/Characters/Blind .prefab
+++ b/Assets/Prefabs/Characters/Blind .prefab
@@ -1,5 +1,133 @@
 %YAML 1.1
 %TAG !u! tag:unity3d.com,2011:
+--- !u!1 &77760971
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 77760972}
+  - component: {fileID: 77760973}
+  m_Layer: 3
+  m_Name: FootStepSound
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &77760972
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 77760971}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 6273823577838093014}
+  m_RootOrder: 7
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!82 &77760973
+AudioSource:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 77760971}
+  m_Enabled: 1
+  serializedVersion: 4
+  OutputAudioMixerGroup: {fileID: 0}
+  m_audioClip: {fileID: 8300000, guid: 1fe0f3aad5369964c89bf121b24cf24c, type: 3}
+  m_PlayOnAwake: 1
+  m_Volume: 1
+  m_Pitch: 1
+  Loop: 0
+  Mute: 0
+  Spatialize: 0
+  SpatializePostEffects: 0
+  Priority: 128
+  DopplerLevel: 1
+  MinDistance: 1
+  MaxDistance: 500
+  Pan2D: 0
+  rolloffMode: 0
+  BypassEffects: 0
+  BypassListenerEffects: 0
+  BypassReverbZones: 0
+  rolloffCustomCurve:
+    serializedVersion: 2
+    m_Curve:
+    - serializedVersion: 3
+      time: 0
+      value: 1
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
+    - serializedVersion: 3
+      time: 1
+      value: 0
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
+    m_PreInfinity: 2
+    m_PostInfinity: 2
+    m_RotationOrder: 4
+  panLevelCustomCurve:
+    serializedVersion: 2
+    m_Curve:
+    - serializedVersion: 3
+      time: 0
+      value: 0
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
+    m_PreInfinity: 2
+    m_PostInfinity: 2
+    m_RotationOrder: 4
+  spreadCustomCurve:
+    serializedVersion: 2
+    m_Curve:
+    - serializedVersion: 3
+      time: 0
+      value: 0
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
+    m_PreInfinity: 2
+    m_PostInfinity: 2
+    m_RotationOrder: 4
+  reverbZoneMixCustomCurve:
+    serializedVersion: 2
+    m_Curve:
+    - serializedVersion: 3
+      time: 0
+      value: 1
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+      weightedMode: 0
+      inWeight: 0.33333334
+      outWeight: 0.33333334
+    m_PreInfinity: 2
+    m_PostInfinity: 2
+    m_RotationOrder: 4
 --- !u!1 &674811622
 GameObject:
   m_ObjectHideFlags: 0
@@ -52,7 +180,7 @@ MonoBehaviour:
   m_Intensity: 0
   m_LightVolumeIntensity: 1
   m_LightVolumeIntensityEnabled: 0
-  m_ApplyToSortingLayers: 0000000031588fa5
+  m_ApplyToSortingLayers: 31588fa500000000b1cd8a984d047bac
   m_LightCookieSprite: {fileID: 0}
   m_DeprecatedPointLightCookieSprite: {fileID: 0}
   m_LightOrder: 0
@@ -261,7 +389,7 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 6273823577571050652}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 1.02, z: 0}
+  m_LocalPosition: {x: 0, y: 1.093, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
@@ -282,14 +410,9 @@ GameObject:
   - component: {fileID: 6273823577838093033}
   - component: {fileID: 6273823577838093015}
   - component: {fileID: 6273823577838093034}
-  - component: {fileID: 6273823577838093036}
-  - component: {fileID: 6273823577838093035}
-  - component: {fileID: 6273823577838093037}
   - component: {fileID: 6273823577838093038}
   - component: {fileID: 6273823577838093039}
   - component: {fileID: 1762368476}
-  - component: {fileID: 1762368477}
-  - component: {fileID: 1762368478}
   m_Layer: 3
   m_Name: 'Blind '
   m_TagString: Blind
@@ -316,6 +439,7 @@ Transform:
   - {fileID: 919443151}
   - {fileID: 2062461389}
   - {fileID: 674811623}
+  - {fileID: 77760972}
   m_Father: {fileID: 0}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -392,10 +516,8 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   moveSpeed: 5
   acceleration: 3
-  footstepLights:
-  - {fileID: 6273823577838093036}
-  - {fileID: 6273823577838093035}
-  footStepAudioSource: {fileID: 0}
+  footstepLights: []
+  footStepAudioSource: {fileID: 77760973}
 --- !u!95 &6273823577838093034
 Animator:
   serializedVersion: 5
@@ -406,7 +528,7 @@ Animator:
   m_GameObject: {fileID: 6273823577838093011}
   m_Enabled: 1
   m_Avatar: {fileID: 0}
-  m_Controller: {fileID: 0}
+  m_Controller: {fileID: 9100000, guid: 1c829553c7199b64a826b8a3587b746c, type: 2}
   m_CullingMode: 0
   m_UpdateMode: 0
   m_ApplyRootMotion: 0
@@ -416,54 +538,6 @@ Animator:
   m_HasTransformHierarchy: 1
   m_AllowConstantClipSamplingOptimization: 1
   m_KeepAnimatorStateOnDisable: 0
---- !u!114 &6273823577838093036
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 6273823577838093011}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 76f4239cdc4dac14dbfedd3d542b43f1, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  LightPrefab: {fileID: 6706706918502213083, guid: 9144f21bdef11594d96b1047d1676078, type: 3}
-  LightPosition: {fileID: 6273823578310235989}
-  DelayForNextLight: 1
-  OffsetForFirstLight: 0.1
---- !u!114 &6273823577838093035
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 6273823577838093011}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 76f4239cdc4dac14dbfedd3d542b43f1, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  LightPrefab: {fileID: 6706706918502213083, guid: 9144f21bdef11594d96b1047d1676078, type: 3}
-  LightPosition: {fileID: 6273823576801207052}
-  DelayForNextLight: 1
-  OffsetForFirstLight: 0.6
---- !u!114 &6273823577838093037
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 6273823577838093011}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 76f4239cdc4dac14dbfedd3d542b43f1, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  LightPrefab: {fileID: 6706706918502213083, guid: 9144f21bdef11594d96b1047d1676078, type: 3}
-  LightPosition: {fileID: 0}
-  DelayForNextLight: -1
-  OffsetForFirstLight: 0
 --- !u!114 &6273823577838093038
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -496,8 +570,8 @@ MonoBehaviour:
   rayCastParent: {fileID: 6273823576794521129}
   whatIsFloor:
     serializedVersion: 2
-    m_Bits: 64
-  wallCheckDistance: 0.65
+    m_Bits: 1088
+  wallCheckDistance: 1.16
   ledgeClimbXOffset1: 0.5
   ledgeClimbYOffset1: 0.47
   ledgeClimbXOffset2: 0.6
@@ -519,40 +593,8 @@ MonoBehaviour:
   climbSpeed: 100
   acceleration: 1.5
   handLights:
-  - {fileID: 1762368477}
-  - {fileID: 1762368478}
---- !u!114 &1762368477
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 6273823577838093011}
-  m_Enabled: 0
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 76f4239cdc4dac14dbfedd3d542b43f1, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  LightPrefab: {fileID: 6706706918502213083, guid: 9144f21bdef11594d96b1047d1676078, type: 3}
-  LightPosition: {fileID: 919443151}
-  DelayForNextLight: 1
-  OffsetForFirstLight: 0.1
---- !u!114 &1762368478
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 6273823577838093011}
-  m_Enabled: 0
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 76f4239cdc4dac14dbfedd3d542b43f1, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  LightPrefab: {fileID: 6706706918502213083, guid: 9144f21bdef11594d96b1047d1676078, type: 3}
-  LightPosition: {fileID: 2062461389}
-  DelayForNextLight: 1
-  OffsetForFirstLight: 0.1
+  - {fileID: 0}
+  - {fileID: 0}
 --- !u!1 &6273823578000710046
 GameObject:
   m_ObjectHideFlags: 0
@@ -685,10 +727,10 @@ SpriteRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
-  m_SortingOrder: 2
-  m_Sprite: {fileID: 21300000, guid: 876aeb92e0baebf4eba09334b03846a4, type: 3}
+  m_SortingLayerID: -1735733839
+  m_SortingLayer: 2
+  m_SortingOrder: 1
+  m_Sprite: {fileID: 21300000, guid: 9aeb1499f133cff4d915edfed789aee7, type: 3}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_FlipX: 0
   m_FlipY: 0

--- a/Assets/Scenes/Level 1 Test Pierma.unity
+++ b/Assets/Scenes/Level 1 Test Pierma.unity
@@ -2527,8 +2527,8 @@ MonoBehaviour:
   - {x: 29.24997, y: -5.500004, z: 0}
   - {x: 4.2499957, y: -5.5000334, z: 0}
   m_ShapePathHash: 0
-  m_Mesh: {fileID: 1366695428}
-  m_InstanceId: 27970
+  m_Mesh: {fileID: 1011615124}
+  m_InstanceId: 27954
 --- !u!1 &550252898
 GameObject:
   m_ObjectHideFlags: 0
@@ -3154,8 +3154,8 @@ MonoBehaviour:
   - {x: -0.9999924, y: 0.49997807, z: 0}
   - {x: -0.9999628, y: -0.49999273, z: 0}
   m_ShapePathHash: 0
-  m_Mesh: {fileID: 1602702241}
-  m_InstanceId: 28014
+  m_Mesh: {fileID: 2091994610}
+  m_InstanceId: 27998
 --- !u!1 &700423402
 GameObject:
   m_ObjectHideFlags: 0
@@ -3668,6 +3668,170 @@ Transform:
   m_CorrespondingSourceObject: {fileID: 7058180585620577788, guid: 62e6ff09b5223014a8fc92cbe99c2979, type: 3}
   m_PrefabInstance: {fileID: 824862667}
   m_PrefabAsset: {fileID: 0}
+--- !u!43 &825203020
+Mesh:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: 
+  serializedVersion: 10
+  m_SubMeshes:
+  - serializedVersion: 2
+    firstByte: 0
+    indexCount: 42
+    topology: 0
+    baseVertex: 0
+    firstVertex: 0
+    vertexCount: 16
+    localAABB:
+      m_Center: {x: -0.0000076293945, y: 0.0000076293945, z: 0}
+      m_Extent: {x: 28.499987, y: 18, z: 0}
+  m_Shapes:
+    vertices: []
+    shapes: []
+    channels: []
+    fullWeights: []
+  m_BindPose: []
+  m_BoneNameHashes: 
+  m_RootBoneNameHash: 0
+  m_BonesAABB: []
+  m_VariableBoneCountWeights:
+    m_Data: 
+  m_MeshCompression: 0
+  m_IsReadable: 1
+  m_KeepVertices: 1
+  m_KeepIndices: 1
+  m_IndexFormat: 0
+  m_IndexBuffer: 00000100020000000300010004000300000004000500030004000600050006000400070002000800000000000900040001000a00020003000b00010005000c00030004000d00070006000e00050007000f000600
+  m_VertexData:
+    serializedVersion: 3
+    m_VertexCount: 16
+    m_Channels:
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 3
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 12
+      format: 0
+      dimension: 4
+    - stream: 0
+      offset: 28
+      format: 0
+      dimension: 4
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    m_DataSize: 704
+    _typelessdata: f5ffe3410400904100000000000080bf000000800000008000000080f5ffe34104009041f5ffe34104009041f5ffe341fcff8fc100000000000000800000803f0000008000000080f5ffe341fcff8fc1f5ffe341fcff8fc1f5ffe3410000003700000000000080bf000000800000008000000080f5ffe341fcff8fc1f5ffe341040090410000e036fcff8fc100000000000000800000803f0000008000000080eeffe3c1fcff8fc1f5ffe341fcff8fc1000000b7fcff8f410000000028b80f35000080bf0000008000000080f5ffe34104009041fdffe3c1f5ff8f41eeffe3c1fcff8fc1000000000000803f468e63350000008000000080eeffe3c1fcff8fc1eeffe3c1fcff8fc1f6ffe3c10000e0b6000000000000803f7d1c47350000008000000080fdffe3c1f5ff8f41eeffe3c1fcff8fc1fdffe3c1f5ff8f41000000004782fb34000080bf0000008000000080fdffe3c1f5ff8f41fdffe3c1f5ff8f41f5ffe3410000003700000000000080bf000000800000008000000080f5ffe341fcff8fc1f5ffe34104009041f5ffe341040090410000000028b80f35000080bf0000008000000080f5ffe34104009041f5ffe34104009041f5ffe341fcff8fc100000000000080bf000000800000008000000080f5ffe341fcff8fc1f5ffe341fcff8fc10000e036fcff8fc100000000000000800000803f0000008000000080eeffe3c1fcff8fc1f5ffe341fcff8fc1eeffe3c1fcff8fc100000000000000800000803f0000008000000080eeffe3c1fcff8fc1eeffe3c1fcff8fc1000000b7fcff8f41000000004782fb34000080bf0000008000000080f5ffe34104009041fdffe3c1f5ff8f41f6ffe3c10000e0b6000000000000803f468e63350000008000000080fdffe3c1f5ff8f41eeffe3c1fcff8fc1fdffe3c1f5ff8f41000000000000803f7d1c47350000008000000080fdffe3c1f5ff8f41fdffe3c1f5ff8f41
+  m_CompressedMesh:
+    m_Vertices:
+      m_NumItems: 0
+      m_Range: 0
+      m_Start: 0
+      m_Data: 
+      m_BitSize: 0
+    m_UV:
+      m_NumItems: 0
+      m_Range: 0
+      m_Start: 0
+      m_Data: 
+      m_BitSize: 0
+    m_Normals:
+      m_NumItems: 0
+      m_Range: 0
+      m_Start: 0
+      m_Data: 
+      m_BitSize: 0
+    m_Tangents:
+      m_NumItems: 0
+      m_Range: 0
+      m_Start: 0
+      m_Data: 
+      m_BitSize: 0
+    m_Weights:
+      m_NumItems: 0
+      m_Data: 
+      m_BitSize: 0
+    m_NormalSigns:
+      m_NumItems: 0
+      m_Data: 
+      m_BitSize: 0
+    m_TangentSigns:
+      m_NumItems: 0
+      m_Data: 
+      m_BitSize: 0
+    m_FloatColors:
+      m_NumItems: 0
+      m_Range: 0
+      m_Start: 0
+      m_Data: 
+      m_BitSize: 0
+    m_BoneIndices:
+      m_NumItems: 0
+      m_Data: 
+      m_BitSize: 0
+    m_Triangles:
+      m_NumItems: 0
+      m_Data: 
+      m_BitSize: 0
+    m_UVInfo: 0
+  m_LocalAABB:
+    m_Center: {x: -0.0000076293945, y: 0.0000076293945, z: 0}
+    m_Extent: {x: 28.499987, y: 18, z: 0}
+  m_MeshUsageFlags: 0
+  m_BakedConvexCollisionMesh: 
+  m_BakedTriangleCollisionMesh: 
+  m_MeshMetrics[0]: 1
+  m_MeshMetrics[1]: 1
+  m_MeshOptimizationFlags: 1
+  m_StreamData:
+    serializedVersion: 2
+    offset: 0
+    size: 0
+    path: 
 --- !u!1001 &851767162
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -3917,7 +4081,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 3633519382720227868, guid: 0d80c842678703e4f9790332ee90f8a6, type: 3}
       propertyPath: m_LocalPosition.x
-      value: 0
+      value: 0.32
       objectReference: {fileID: 0}
     - target: {fileID: 3633519382720227868, guid: 0d80c842678703e4f9790332ee90f8a6, type: 3}
       propertyPath: m_LocalPosition.y
@@ -14111,6 +14275,170 @@ Tilemap:
     e31: 0
     e32: 0
     e33: 1
+--- !u!43 &1011615124
+Mesh:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: 
+  serializedVersion: 10
+  m_SubMeshes:
+  - serializedVersion: 2
+    firstByte: 0
+    indexCount: 90
+    topology: 0
+    baseVertex: 0
+    firstVertex: 0
+    vertexCount: 32
+    localAABB:
+      m_Center: {x: 5.749996, y: 2.500011, z: 0}
+      m_Extent: {x: 23.5, y: 9.999985, z: 0}
+  m_Shapes:
+    vertices: []
+    shapes: []
+    channels: []
+    fullWeights: []
+  m_BindPose: []
+  m_BoneNameHashes: 
+  m_RootBoneNameHash: 0
+  m_BonesAABB: []
+  m_VariableBoneCountWeights:
+    m_Data: 
+  m_MeshCompression: 0
+  m_IsReadable: 1
+  m_KeepVertices: 1
+  m_KeepIndices: 1
+  m_IndexFormat: 0
+  m_IndexBuffer: 00000100020001000000030004000500060007000500040007000800050001000800070003000800010003000900080003000a00090003000b000a0003000c000b0003000d000c0003000e000d000e0003000f00020010000000000011000300010012000200070013000100030014000f000600150004000400160007000500170006000800180005000900190008000a001a0009000b001b000a000c001c000b000d001d000c000e001e000d000f001f000e00
+  m_VertexData:
+    serializedVersion: 3
+    m_VertexCount: 32
+    m_Channels:
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 3
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 12
+      format: 0
+      dimension: 4
+    - stream: 0
+      offset: 28
+      format: 0
+      dimension: 4
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    m_DataSize: 1408
+    _typelessdata: f7ff8740caffefc0000000000000803f000000800000008000000080f7ff8740caffefc0f7ff8740caffefc0f7ff87404600b0c0000000005db89e35000080bf0000008000000080f7ff87404600b0c0f7ff87404600b0c0f7ff87400800d0c0000000000000803f000000800000008000000080f7ff87404600b0c0f7ff8740caffefc00800d8c0caffefc00000000000000080000080bf0000000000000080f7ff8740caffefc002008ec1caffefc0f0ffe9410800b0c0000000000000803f871cc7b50000008000000080f0ffe9410800b0c0f0ffe9410800b0c0feffe941deff474100000000b2aa2a350000803f0000008000000080feffe941deff4741feffe941deff4741f7ffe941b4ff5f40000000000000803f871cc7b50000008000000080feffe941deff4741f0ffe9410800b0c0f7ff85412700b0c0000000005db89e35000080bf0000008000000080f0ffe9410800b0c0f7ff87404600b0c01600d840edff474100000000b2aa2a350000803f0000008000000080e6ff7bc1fcff4741feffe941deff4741e6ff7bc1fcff474100000000000080bf190020360000008000000080e6ff7bc1fcff4741e6ff7bc1fcff4741f5ff7bc11600d04000000000000080bf1a002036000000800000008004007cc1a801003fe6ff7bc1fcff474104007cc1a801003f00000000f60076b70000803f000000800000008004007cc1a801003f04007cc1a801003ffaff85c1b200003f00000000d70076b70000803f0000008000000080f3ff8dc178ffff3e04007cc1a801003ff3ff8dc178ffff3e00000000000080bf370060360000008000000080f3ff8dc178ffff3ef3ff8dc178ffff3efaff8dc1d2ff5fc000000000000080bf1f008036000000800000008002008ec1caffefc0f3ff8dc178ffff3e02008ec1caffefc00000000000000080000080bf000000000000008002008ec1caffefc002008ec1caffefc0f7ff87400800d0c0000000000000803f000000800000008000000080f7ff87404600b0c0f7ff8740caffefc0f7ff8740caffefc00000000000000080000080bf0000000000000080f7ff8740caffefc0f7ff8740caffefc0f7ff87404600b0c0000000000000803f000000800000008000000080f7ff87404600b0c0f7ff87404600b0c0f7ff85412700b0c0000000005db89e35000080bf0000008000000080f0ffe9410800b0c0f7ff87404600b0c00800d8c0caffefc00000000000000080000080bf0000000000000080f7ff8740caffefc002008ec1caffefc0f7ffe941b4ff5f40000000000000803f871cc7b50000008000000080feffe941deff4741f0ffe9410800b0c0f0ffe9410800b0c0000000005db89e35000080bf0000008000000080f0ffe9410800b0c0f0ffe9410800b0c0feffe941deff4741000000000000803f871cc7b50000008000000080feffe941deff4741feffe941deff47411600d840edff474100000000b2aa2a350000803f0000008000000080e6ff7bc1fcff4741feffe941deff4741e6ff7bc1fcff474100000000b2aa2a350000803f0000008000000080e6ff7bc1fcff4741e6ff7bc1fcff4741f5ff7bc11600d04000000000000080bf19002036000000800000008004007cc1a801003fe6ff7bc1fcff474104007cc1a801003f00000000000080bf1a002036000000800000008004007cc1a801003f04007cc1a801003ffaff85c1b200003f00000000f60076b70000803f0000008000000080f3ff8dc178ffff3e04007cc1a801003ff3ff8dc178ffff3e00000000d70076b70000803f0000008000000080f3ff8dc178ffff3ef3ff8dc178ffff3efaff8dc1d2ff5fc000000000000080bf37006036000000800000008002008ec1caffefc0f3ff8dc178ffff3e02008ec1caffefc000000000000080bf1f008036000000800000008002008ec1caffefc002008ec1caffefc0
+  m_CompressedMesh:
+    m_Vertices:
+      m_NumItems: 0
+      m_Range: 0
+      m_Start: 0
+      m_Data: 
+      m_BitSize: 0
+    m_UV:
+      m_NumItems: 0
+      m_Range: 0
+      m_Start: 0
+      m_Data: 
+      m_BitSize: 0
+    m_Normals:
+      m_NumItems: 0
+      m_Range: 0
+      m_Start: 0
+      m_Data: 
+      m_BitSize: 0
+    m_Tangents:
+      m_NumItems: 0
+      m_Range: 0
+      m_Start: 0
+      m_Data: 
+      m_BitSize: 0
+    m_Weights:
+      m_NumItems: 0
+      m_Data: 
+      m_BitSize: 0
+    m_NormalSigns:
+      m_NumItems: 0
+      m_Data: 
+      m_BitSize: 0
+    m_TangentSigns:
+      m_NumItems: 0
+      m_Data: 
+      m_BitSize: 0
+    m_FloatColors:
+      m_NumItems: 0
+      m_Range: 0
+      m_Start: 0
+      m_Data: 
+      m_BitSize: 0
+    m_BoneIndices:
+      m_NumItems: 0
+      m_Data: 
+      m_BitSize: 0
+    m_Triangles:
+      m_NumItems: 0
+      m_Data: 
+      m_BitSize: 0
+    m_UVInfo: 0
+  m_LocalAABB:
+    m_Center: {x: 5.749996, y: 2.500011, z: 0}
+    m_Extent: {x: 23.5, y: 9.999985, z: 0}
+  m_MeshUsageFlags: 0
+  m_BakedConvexCollisionMesh: 
+  m_BakedTriangleCollisionMesh: 
+  m_MeshMetrics[0]: 1
+  m_MeshMetrics[1]: 1
+  m_MeshOptimizationFlags: 1
+  m_StreamData:
+    serializedVersion: 2
+    offset: 0
+    size: 0
+    path: 
 --- !u!1 &1016562955
 GameObject:
   m_ObjectHideFlags: 0
@@ -39293,170 +39621,6 @@ Rigidbody2D:
   m_SleepingMode: 1
   m_CollisionDetection: 0
   m_Constraints: 0
---- !u!43 &1366695428
-Mesh:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_Name: 
-  serializedVersion: 10
-  m_SubMeshes:
-  - serializedVersion: 2
-    firstByte: 0
-    indexCount: 90
-    topology: 0
-    baseVertex: 0
-    firstVertex: 0
-    vertexCount: 32
-    localAABB:
-      m_Center: {x: 5.749996, y: 2.500011, z: 0}
-      m_Extent: {x: 23.5, y: 9.999985, z: 0}
-  m_Shapes:
-    vertices: []
-    shapes: []
-    channels: []
-    fullWeights: []
-  m_BindPose: []
-  m_BoneNameHashes: 
-  m_RootBoneNameHash: 0
-  m_BonesAABB: []
-  m_VariableBoneCountWeights:
-    m_Data: 
-  m_MeshCompression: 0
-  m_IsReadable: 1
-  m_KeepVertices: 1
-  m_KeepIndices: 1
-  m_IndexFormat: 0
-  m_IndexBuffer: 00000100020001000000030004000500060007000500040007000800050001000800070003000800010003000900080003000a00090003000b000a0003000c000b0003000d000c0003000e000d000e0003000f00020010000000000011000300010012000200070013000100030014000f000600150004000400160007000500170006000800180005000900190008000a001a0009000b001b000a000c001c000b000d001d000c000e001e000d000f001f000e00
-  m_VertexData:
-    serializedVersion: 3
-    m_VertexCount: 32
-    m_Channels:
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 3
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 12
-      format: 0
-      dimension: 4
-    - stream: 0
-      offset: 28
-      format: 0
-      dimension: 4
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    m_DataSize: 1408
-    _typelessdata: f7ff8740caffefc0000000000000803f000000800000008000000080f7ff8740caffefc0f7ff8740caffefc0f7ff87404600b0c0000000005db89e35000080bf0000008000000080f7ff87404600b0c0f7ff87404600b0c0f7ff87400800d0c0000000000000803f000000800000008000000080f7ff87404600b0c0f7ff8740caffefc00800d8c0caffefc00000000000000080000080bf0000000000000080f7ff8740caffefc002008ec1caffefc0f0ffe9410800b0c0000000000000803f871cc7b50000008000000080f0ffe9410800b0c0f0ffe9410800b0c0feffe941deff474100000000b2aa2a350000803f0000008000000080feffe941deff4741feffe941deff4741f7ffe941b4ff5f40000000000000803f871cc7b50000008000000080feffe941deff4741f0ffe9410800b0c0f7ff85412700b0c0000000005db89e35000080bf0000008000000080f0ffe9410800b0c0f7ff87404600b0c01600d840edff474100000000b2aa2a350000803f0000008000000080e6ff7bc1fcff4741feffe941deff4741e6ff7bc1fcff474100000000000080bf190020360000008000000080e6ff7bc1fcff4741e6ff7bc1fcff4741f5ff7bc11600d04000000000000080bf1a002036000000800000008004007cc1a801003fe6ff7bc1fcff474104007cc1a801003f00000000f60076b70000803f000000800000008004007cc1a801003f04007cc1a801003ffaff85c1b200003f00000000d70076b70000803f0000008000000080f3ff8dc178ffff3e04007cc1a801003ff3ff8dc178ffff3e00000000000080bf370060360000008000000080f3ff8dc178ffff3ef3ff8dc178ffff3efaff8dc1d2ff5fc000000000000080bf1f008036000000800000008002008ec1caffefc0f3ff8dc178ffff3e02008ec1caffefc00000000000000080000080bf000000000000008002008ec1caffefc002008ec1caffefc0f7ff87400800d0c0000000000000803f000000800000008000000080f7ff87404600b0c0f7ff8740caffefc0f7ff8740caffefc00000000000000080000080bf0000000000000080f7ff8740caffefc0f7ff8740caffefc0f7ff87404600b0c0000000000000803f000000800000008000000080f7ff87404600b0c0f7ff87404600b0c0f7ff85412700b0c0000000005db89e35000080bf0000008000000080f0ffe9410800b0c0f7ff87404600b0c00800d8c0caffefc00000000000000080000080bf0000000000000080f7ff8740caffefc002008ec1caffefc0f7ffe941b4ff5f40000000000000803f871cc7b50000008000000080feffe941deff4741f0ffe9410800b0c0f0ffe9410800b0c0000000005db89e35000080bf0000008000000080f0ffe9410800b0c0f0ffe9410800b0c0feffe941deff4741000000000000803f871cc7b50000008000000080feffe941deff4741feffe941deff47411600d840edff474100000000b2aa2a350000803f0000008000000080e6ff7bc1fcff4741feffe941deff4741e6ff7bc1fcff474100000000b2aa2a350000803f0000008000000080e6ff7bc1fcff4741e6ff7bc1fcff4741f5ff7bc11600d04000000000000080bf19002036000000800000008004007cc1a801003fe6ff7bc1fcff474104007cc1a801003f00000000000080bf1a002036000000800000008004007cc1a801003f04007cc1a801003ffaff85c1b200003f00000000f60076b70000803f0000008000000080f3ff8dc178ffff3e04007cc1a801003ff3ff8dc178ffff3e00000000d70076b70000803f0000008000000080f3ff8dc178ffff3ef3ff8dc178ffff3efaff8dc1d2ff5fc000000000000080bf37006036000000800000008002008ec1caffefc0f3ff8dc178ffff3e02008ec1caffefc000000000000080bf1f008036000000800000008002008ec1caffefc002008ec1caffefc0
-  m_CompressedMesh:
-    m_Vertices:
-      m_NumItems: 0
-      m_Range: 0
-      m_Start: 0
-      m_Data: 
-      m_BitSize: 0
-    m_UV:
-      m_NumItems: 0
-      m_Range: 0
-      m_Start: 0
-      m_Data: 
-      m_BitSize: 0
-    m_Normals:
-      m_NumItems: 0
-      m_Range: 0
-      m_Start: 0
-      m_Data: 
-      m_BitSize: 0
-    m_Tangents:
-      m_NumItems: 0
-      m_Range: 0
-      m_Start: 0
-      m_Data: 
-      m_BitSize: 0
-    m_Weights:
-      m_NumItems: 0
-      m_Data: 
-      m_BitSize: 0
-    m_NormalSigns:
-      m_NumItems: 0
-      m_Data: 
-      m_BitSize: 0
-    m_TangentSigns:
-      m_NumItems: 0
-      m_Data: 
-      m_BitSize: 0
-    m_FloatColors:
-      m_NumItems: 0
-      m_Range: 0
-      m_Start: 0
-      m_Data: 
-      m_BitSize: 0
-    m_BoneIndices:
-      m_NumItems: 0
-      m_Data: 
-      m_BitSize: 0
-    m_Triangles:
-      m_NumItems: 0
-      m_Data: 
-      m_BitSize: 0
-    m_UVInfo: 0
-  m_LocalAABB:
-    m_Center: {x: 5.749996, y: 2.500011, z: 0}
-    m_Extent: {x: 23.5, y: 9.999985, z: 0}
-  m_MeshUsageFlags: 0
-  m_BakedConvexCollisionMesh: 
-  m_BakedTriangleCollisionMesh: 
-  m_MeshMetrics[0]: 1
-  m_MeshMetrics[1]: 1
-  m_MeshOptimizationFlags: 1
-  m_StreamData:
-    serializedVersion: 2
-    offset: 0
-    size: 0
-    path: 
 --- !u!1001 &1403874554
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -40378,6 +40542,10 @@ PrefabInstance:
       propertyPath: m_ApplyToSortingLayers.Array.data[3]
       value: -1401224115
       objectReference: {fileID: 0}
+    - target: {fileID: 6273823577571050653, guid: f92512e991fcb2f4eb5205899be94ef9, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 1.093
+      objectReference: {fileID: 0}
     - target: {fileID: 6273823577838093011, guid: f92512e991fcb2f4eb5205899be94ef9, type: 3}
       propertyPath: m_Name
       value: 'Blind '
@@ -40388,11 +40556,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 6273823577838093014, guid: f92512e991fcb2f4eb5205899be94ef9, type: 3}
       propertyPath: m_LocalPosition.x
-      value: 15.79
+      value: 30
       objectReference: {fileID: 0}
     - target: {fileID: 6273823577838093014, guid: f92512e991fcb2f4eb5205899be94ef9, type: 3}
       propertyPath: m_LocalPosition.y
-      value: -5.54
+      value: -36.4
       objectReference: {fileID: 0}
     - target: {fileID: 6273823577838093014, guid: f92512e991fcb2f4eb5205899be94ef9, type: 3}
       propertyPath: m_LocalPosition.z
@@ -40597,170 +40765,6 @@ Transform:
   m_CorrespondingSourceObject: {fileID: 155338233135811590, guid: e10accaabb41a0d4c844a2f49cee66f9, type: 3}
   m_PrefabInstance: {fileID: 1602670543}
   m_PrefabAsset: {fileID: 0}
---- !u!43 &1602702241
-Mesh:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_Name: 
-  serializedVersion: 10
-  m_SubMeshes:
-  - serializedVersion: 2
-    firstByte: 0
-    indexCount: 42
-    topology: 0
-    baseVertex: 0
-    firstVertex: 0
-    vertexCount: 16
-    localAABB:
-      m_Center: {x: -0.0000071525574, y: 0.0000072717667, z: 0}
-      m_Extent: {x: 0.9999852, y: 0.5, z: 0}
-  m_Shapes:
-    vertices: []
-    shapes: []
-    channels: []
-    fullWeights: []
-  m_BindPose: []
-  m_BoneNameHashes: 
-  m_RootBoneNameHash: 0
-  m_BonesAABB: []
-  m_VariableBoneCountWeights:
-    m_Data: 
-  m_MeshCompression: 0
-  m_IsReadable: 1
-  m_KeepVertices: 1
-  m_KeepIndices: 1
-  m_IndexFormat: 0
-  m_IndexBuffer: 00000100020000000300010004000300000004000500030004000600050006000400070002000800000000000900040001000a00020003000b00010005000c00030004000d00070006000e00050007000f000600
-  m_VertexData:
-    serializedVersion: 3
-    m_VertexCount: 16
-    m_Channels:
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 3
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 12
-      format: 0
-      dimension: 4
-    - stream: 0
-      offset: 28
-      format: 0
-      dimension: 4
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    m_DataSize: 704
-    _typelessdata: 90fe7f3f7a00003f00000000000080bf00000080000000800000008090fe7f3f7a00003f90fe7f3f7a00003f90fe7f3f0cffffbe00000000000000800000803f000000800000008090fe7f3f0cffffbe90fe7f3f0cffffbe90fe7f3f0000f43600000000000080bf00000080000000800000008090fe7f3f0cffffbe90fe7f3f7a00003f000000370cffffbe00000000000000800000803f000000800000008090fd7fbf0cffffbe90fe7f3f0cffffbe0000f0b60affff3e00000000ed007537000080bf000000800000008090fe7f3f7a00003f80ff7fbf20fdff3e90fd7fbf0cffffbe000000000000803fdb01f837000000800000008090fd7fbf0cffffbe90fd7fbf0cffffbe88fe7fbf0000f6b6000000000000803fdb01f837000000800000008080ff7fbf20fdff3e90fd7fbf0cffffbe80ff7fbf20fdff3e00000000ed007537000080bf000000800000008080ff7fbf20fdff3e80ff7fbf20fdff3e90fe7f3f0000f43600000000000080bf00000080000000800000008090fe7f3f0cffffbe90fe7f3f7a00003f90fe7f3f7a00003f00000000ed007537000080bf000000800000008090fe7f3f7a00003f90fe7f3f7a00003f90fe7f3f0cffffbe00000000000080bf00000080000000800000008090fe7f3f0cffffbe90fe7f3f0cffffbe000000370cffffbe00000000000000800000803f000000800000008090fd7fbf0cffffbe90fe7f3f0cffffbe90fd7fbf0cffffbe00000000000000800000803f000000800000008090fd7fbf0cffffbe90fd7fbf0cffffbe0000f0b60affff3e00000000ed007537000080bf000000800000008090fe7f3f7a00003f80ff7fbf20fdff3e88fe7fbf0000f6b6000000000000803fdb01f837000000800000008080ff7fbf20fdff3e90fd7fbf0cffffbe80ff7fbf20fdff3e000000000000803fdb01f837000000800000008080ff7fbf20fdff3e80ff7fbf20fdff3e
-  m_CompressedMesh:
-    m_Vertices:
-      m_NumItems: 0
-      m_Range: 0
-      m_Start: 0
-      m_Data: 
-      m_BitSize: 0
-    m_UV:
-      m_NumItems: 0
-      m_Range: 0
-      m_Start: 0
-      m_Data: 
-      m_BitSize: 0
-    m_Normals:
-      m_NumItems: 0
-      m_Range: 0
-      m_Start: 0
-      m_Data: 
-      m_BitSize: 0
-    m_Tangents:
-      m_NumItems: 0
-      m_Range: 0
-      m_Start: 0
-      m_Data: 
-      m_BitSize: 0
-    m_Weights:
-      m_NumItems: 0
-      m_Data: 
-      m_BitSize: 0
-    m_NormalSigns:
-      m_NumItems: 0
-      m_Data: 
-      m_BitSize: 0
-    m_TangentSigns:
-      m_NumItems: 0
-      m_Data: 
-      m_BitSize: 0
-    m_FloatColors:
-      m_NumItems: 0
-      m_Range: 0
-      m_Start: 0
-      m_Data: 
-      m_BitSize: 0
-    m_BoneIndices:
-      m_NumItems: 0
-      m_Data: 
-      m_BitSize: 0
-    m_Triangles:
-      m_NumItems: 0
-      m_Data: 
-      m_BitSize: 0
-    m_UVInfo: 0
-  m_LocalAABB:
-    m_Center: {x: -0.0000071525574, y: 0.0000072717667, z: 0}
-    m_Extent: {x: 0.9999852, y: 0.5, z: 0}
-  m_MeshUsageFlags: 0
-  m_BakedConvexCollisionMesh: 
-  m_BakedTriangleCollisionMesh: 
-  m_MeshMetrics[0]: 1
-  m_MeshMetrics[1]: 1
-  m_MeshOptimizationFlags: 1
-  m_StreamData:
-    serializedVersion: 2
-    offset: 0
-    size: 0
-    path: 
 --- !u!43 &1609042297
 Mesh:
   m_ObjectHideFlags: 0
@@ -41627,170 +41631,6 @@ Transform:
   m_Father: {fileID: 1873156098}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!43 &1751883322
-Mesh:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_Name: 
-  serializedVersion: 10
-  m_SubMeshes:
-  - serializedVersion: 2
-    firstByte: 0
-    indexCount: 42
-    topology: 0
-    baseVertex: 0
-    firstVertex: 0
-    vertexCount: 16
-    localAABB:
-      m_Center: {x: -0.0000076293945, y: 0.0000076293945, z: 0}
-      m_Extent: {x: 28.499987, y: 18, z: 0}
-  m_Shapes:
-    vertices: []
-    shapes: []
-    channels: []
-    fullWeights: []
-  m_BindPose: []
-  m_BoneNameHashes: 
-  m_RootBoneNameHash: 0
-  m_BonesAABB: []
-  m_VariableBoneCountWeights:
-    m_Data: 
-  m_MeshCompression: 0
-  m_IsReadable: 1
-  m_KeepVertices: 1
-  m_KeepIndices: 1
-  m_IndexFormat: 0
-  m_IndexBuffer: 00000100020000000300010004000300000004000500030004000600050006000400070002000800000000000900040001000a00020003000b00010005000c00030004000d00070006000e00050007000f000600
-  m_VertexData:
-    serializedVersion: 3
-    m_VertexCount: 16
-    m_Channels:
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 3
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 12
-      format: 0
-      dimension: 4
-    - stream: 0
-      offset: 28
-      format: 0
-      dimension: 4
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    - stream: 0
-      offset: 0
-      format: 0
-      dimension: 0
-    m_DataSize: 704
-    _typelessdata: f5ffe3410400904100000000000080bf000000800000008000000080f5ffe34104009041f5ffe34104009041f5ffe341fcff8fc100000000000000800000803f0000008000000080f5ffe341fcff8fc1f5ffe341fcff8fc1f5ffe3410000003700000000000080bf000000800000008000000080f5ffe341fcff8fc1f5ffe341040090410000e036fcff8fc100000000000000800000803f0000008000000080eeffe3c1fcff8fc1f5ffe341fcff8fc1000000b7fcff8f410000000028b80f35000080bf0000008000000080f5ffe34104009041fdffe3c1f5ff8f41eeffe3c1fcff8fc1000000000000803f468e63350000008000000080eeffe3c1fcff8fc1eeffe3c1fcff8fc1f6ffe3c10000e0b6000000000000803f7d1c47350000008000000080fdffe3c1f5ff8f41eeffe3c1fcff8fc1fdffe3c1f5ff8f41000000004782fb34000080bf0000008000000080fdffe3c1f5ff8f41fdffe3c1f5ff8f41f5ffe3410000003700000000000080bf000000800000008000000080f5ffe341fcff8fc1f5ffe34104009041f5ffe341040090410000000028b80f35000080bf0000008000000080f5ffe34104009041f5ffe34104009041f5ffe341fcff8fc100000000000080bf000000800000008000000080f5ffe341fcff8fc1f5ffe341fcff8fc10000e036fcff8fc100000000000000800000803f0000008000000080eeffe3c1fcff8fc1f5ffe341fcff8fc1eeffe3c1fcff8fc100000000000000800000803f0000008000000080eeffe3c1fcff8fc1eeffe3c1fcff8fc1000000b7fcff8f41000000004782fb34000080bf0000008000000080f5ffe34104009041fdffe3c1f5ff8f41f6ffe3c10000e0b6000000000000803f468e63350000008000000080fdffe3c1f5ff8f41eeffe3c1fcff8fc1fdffe3c1f5ff8f41000000000000803f7d1c47350000008000000080fdffe3c1f5ff8f41fdffe3c1f5ff8f41
-  m_CompressedMesh:
-    m_Vertices:
-      m_NumItems: 0
-      m_Range: 0
-      m_Start: 0
-      m_Data: 
-      m_BitSize: 0
-    m_UV:
-      m_NumItems: 0
-      m_Range: 0
-      m_Start: 0
-      m_Data: 
-      m_BitSize: 0
-    m_Normals:
-      m_NumItems: 0
-      m_Range: 0
-      m_Start: 0
-      m_Data: 
-      m_BitSize: 0
-    m_Tangents:
-      m_NumItems: 0
-      m_Range: 0
-      m_Start: 0
-      m_Data: 
-      m_BitSize: 0
-    m_Weights:
-      m_NumItems: 0
-      m_Data: 
-      m_BitSize: 0
-    m_NormalSigns:
-      m_NumItems: 0
-      m_Data: 
-      m_BitSize: 0
-    m_TangentSigns:
-      m_NumItems: 0
-      m_Data: 
-      m_BitSize: 0
-    m_FloatColors:
-      m_NumItems: 0
-      m_Range: 0
-      m_Start: 0
-      m_Data: 
-      m_BitSize: 0
-    m_BoneIndices:
-      m_NumItems: 0
-      m_Data: 
-      m_BitSize: 0
-    m_Triangles:
-      m_NumItems: 0
-      m_Data: 
-      m_BitSize: 0
-    m_UVInfo: 0
-  m_LocalAABB:
-    m_Center: {x: -0.0000076293945, y: 0.0000076293945, z: 0}
-    m_Extent: {x: 28.499987, y: 18, z: 0}
-  m_MeshUsageFlags: 0
-  m_BakedConvexCollisionMesh: 
-  m_BakedTriangleCollisionMesh: 
-  m_MeshMetrics[0]: 1
-  m_MeshMetrics[1]: 1
-  m_MeshOptimizationFlags: 1
-  m_StreamData:
-    serializedVersion: 2
-    offset: 0
-    size: 0
-    path: 
 --- !u!1 &1757962643 stripped
 GameObject:
   m_CorrespondingSourceObject: {fileID: 6273823577838093011, guid: f92512e991fcb2f4eb5205899be94ef9, type: 3}
@@ -42762,6 +42602,170 @@ Transform:
   m_CorrespondingSourceObject: {fileID: 7989452208551681461, guid: a271c3a777b5e3c4780744627d209ff5, type: 3}
   m_PrefabInstance: {fileID: 1977114379}
   m_PrefabAsset: {fileID: 0}
+--- !u!43 &2091994610
+Mesh:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: 
+  serializedVersion: 10
+  m_SubMeshes:
+  - serializedVersion: 2
+    firstByte: 0
+    indexCount: 42
+    topology: 0
+    baseVertex: 0
+    firstVertex: 0
+    vertexCount: 16
+    localAABB:
+      m_Center: {x: -0.0000071525574, y: 0.0000072717667, z: 0}
+      m_Extent: {x: 0.9999852, y: 0.5, z: 0}
+  m_Shapes:
+    vertices: []
+    shapes: []
+    channels: []
+    fullWeights: []
+  m_BindPose: []
+  m_BoneNameHashes: 
+  m_RootBoneNameHash: 0
+  m_BonesAABB: []
+  m_VariableBoneCountWeights:
+    m_Data: 
+  m_MeshCompression: 0
+  m_IsReadable: 1
+  m_KeepVertices: 1
+  m_KeepIndices: 1
+  m_IndexFormat: 0
+  m_IndexBuffer: 00000100020000000300010004000300000004000500030004000600050006000400070002000800000000000900040001000a00020003000b00010005000c00030004000d00070006000e00050007000f000600
+  m_VertexData:
+    serializedVersion: 3
+    m_VertexCount: 16
+    m_Channels:
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 3
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 12
+      format: 0
+      dimension: 4
+    - stream: 0
+      offset: 28
+      format: 0
+      dimension: 4
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    - stream: 0
+      offset: 0
+      format: 0
+      dimension: 0
+    m_DataSize: 704
+    _typelessdata: 90fe7f3f7a00003f00000000000080bf00000080000000800000008090fe7f3f7a00003f90fe7f3f7a00003f90fe7f3f0cffffbe00000000000000800000803f000000800000008090fe7f3f0cffffbe90fe7f3f0cffffbe90fe7f3f0000f43600000000000080bf00000080000000800000008090fe7f3f0cffffbe90fe7f3f7a00003f000000370cffffbe00000000000000800000803f000000800000008090fd7fbf0cffffbe90fe7f3f0cffffbe0000f0b60affff3e00000000ed007537000080bf000000800000008090fe7f3f7a00003f80ff7fbf20fdff3e90fd7fbf0cffffbe000000000000803fdb01f837000000800000008090fd7fbf0cffffbe90fd7fbf0cffffbe88fe7fbf0000f6b6000000000000803fdb01f837000000800000008080ff7fbf20fdff3e90fd7fbf0cffffbe80ff7fbf20fdff3e00000000ed007537000080bf000000800000008080ff7fbf20fdff3e80ff7fbf20fdff3e90fe7f3f0000f43600000000000080bf00000080000000800000008090fe7f3f0cffffbe90fe7f3f7a00003f90fe7f3f7a00003f00000000ed007537000080bf000000800000008090fe7f3f7a00003f90fe7f3f7a00003f90fe7f3f0cffffbe00000000000080bf00000080000000800000008090fe7f3f0cffffbe90fe7f3f0cffffbe000000370cffffbe00000000000000800000803f000000800000008090fd7fbf0cffffbe90fe7f3f0cffffbe90fd7fbf0cffffbe00000000000000800000803f000000800000008090fd7fbf0cffffbe90fd7fbf0cffffbe0000f0b60affff3e00000000ed007537000080bf000000800000008090fe7f3f7a00003f80ff7fbf20fdff3e88fe7fbf0000f6b6000000000000803fdb01f837000000800000008080ff7fbf20fdff3e90fd7fbf0cffffbe80ff7fbf20fdff3e000000000000803fdb01f837000000800000008080ff7fbf20fdff3e80ff7fbf20fdff3e
+  m_CompressedMesh:
+    m_Vertices:
+      m_NumItems: 0
+      m_Range: 0
+      m_Start: 0
+      m_Data: 
+      m_BitSize: 0
+    m_UV:
+      m_NumItems: 0
+      m_Range: 0
+      m_Start: 0
+      m_Data: 
+      m_BitSize: 0
+    m_Normals:
+      m_NumItems: 0
+      m_Range: 0
+      m_Start: 0
+      m_Data: 
+      m_BitSize: 0
+    m_Tangents:
+      m_NumItems: 0
+      m_Range: 0
+      m_Start: 0
+      m_Data: 
+      m_BitSize: 0
+    m_Weights:
+      m_NumItems: 0
+      m_Data: 
+      m_BitSize: 0
+    m_NormalSigns:
+      m_NumItems: 0
+      m_Data: 
+      m_BitSize: 0
+    m_TangentSigns:
+      m_NumItems: 0
+      m_Data: 
+      m_BitSize: 0
+    m_FloatColors:
+      m_NumItems: 0
+      m_Range: 0
+      m_Start: 0
+      m_Data: 
+      m_BitSize: 0
+    m_BoneIndices:
+      m_NumItems: 0
+      m_Data: 
+      m_BitSize: 0
+    m_Triangles:
+      m_NumItems: 0
+      m_Data: 
+      m_BitSize: 0
+    m_UVInfo: 0
+  m_LocalAABB:
+    m_Center: {x: -0.0000071525574, y: 0.0000072717667, z: 0}
+    m_Extent: {x: 0.9999852, y: 0.5, z: 0}
+  m_MeshUsageFlags: 0
+  m_BakedConvexCollisionMesh: 
+  m_BakedTriangleCollisionMesh: 
+  m_MeshMetrics[0]: 1
+  m_MeshMetrics[1]: 1
+  m_MeshOptimizationFlags: 1
+  m_StreamData:
+    serializedVersion: 2
+    offset: 0
+    size: 0
+    path: 
 --- !u!1 &2093861751
 GameObject:
   m_ObjectHideFlags: 0
@@ -42819,8 +42823,8 @@ MonoBehaviour:
   - {x: -28.499994, y: 17.999979, z: 0}
   - {x: -28.499966, y: -17.999992, z: 0}
   m_ShapePathHash: 0
-  m_Mesh: {fileID: 1751883322}
-  m_InstanceId: 28466
+  m_Mesh: {fileID: 825203020}
+  m_InstanceId: 28438
 --- !u!1 &2133855970
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Scenes/Level 1 Test Pierma.unity
+++ b/Assets/Scenes/Level 1 Test Pierma.unity
@@ -549,134 +549,6 @@ Transform:
   m_Father: {fileID: 104518862}
   m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &77760971
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 77760972}
-  - component: {fileID: 77760973}
-  m_Layer: 3
-  m_Name: FootStepSound
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &77760972
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 77760971}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 1762368478}
-  m_RootOrder: 7
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!82 &77760973
-AudioSource:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 77760971}
-  m_Enabled: 1
-  serializedVersion: 4
-  OutputAudioMixerGroup: {fileID: 0}
-  m_audioClip: {fileID: 8300000, guid: 1fe0f3aad5369964c89bf121b24cf24c, type: 3}
-  m_PlayOnAwake: 1
-  m_Volume: 1
-  m_Pitch: 1
-  Loop: 0
-  Mute: 0
-  Spatialize: 0
-  SpatializePostEffects: 0
-  Priority: 128
-  DopplerLevel: 1
-  MinDistance: 1
-  MaxDistance: 500
-  Pan2D: 0
-  rolloffMode: 0
-  BypassEffects: 0
-  BypassListenerEffects: 0
-  BypassReverbZones: 0
-  rolloffCustomCurve:
-    serializedVersion: 2
-    m_Curve:
-    - serializedVersion: 3
-      time: 0
-      value: 1
-      inSlope: 0
-      outSlope: 0
-      tangentMode: 0
-      weightedMode: 0
-      inWeight: 0.33333334
-      outWeight: 0.33333334
-    - serializedVersion: 3
-      time: 1
-      value: 0
-      inSlope: 0
-      outSlope: 0
-      tangentMode: 0
-      weightedMode: 0
-      inWeight: 0.33333334
-      outWeight: 0.33333334
-    m_PreInfinity: 2
-    m_PostInfinity: 2
-    m_RotationOrder: 4
-  panLevelCustomCurve:
-    serializedVersion: 2
-    m_Curve:
-    - serializedVersion: 3
-      time: 0
-      value: 0
-      inSlope: 0
-      outSlope: 0
-      tangentMode: 0
-      weightedMode: 0
-      inWeight: 0.33333334
-      outWeight: 0.33333334
-    m_PreInfinity: 2
-    m_PostInfinity: 2
-    m_RotationOrder: 4
-  spreadCustomCurve:
-    serializedVersion: 2
-    m_Curve:
-    - serializedVersion: 3
-      time: 0
-      value: 0
-      inSlope: 0
-      outSlope: 0
-      tangentMode: 0
-      weightedMode: 0
-      inWeight: 0.33333334
-      outWeight: 0.33333334
-    m_PreInfinity: 2
-    m_PostInfinity: 2
-    m_RotationOrder: 4
-  reverbZoneMixCustomCurve:
-    serializedVersion: 2
-    m_Curve:
-    - serializedVersion: 3
-      time: 0
-      value: 1
-      inSlope: 0
-      outSlope: 0
-      tangentMode: 0
-      weightedMode: 0
-      inWeight: 0.33333334
-      outWeight: 0.33333334
-    m_PreInfinity: 2
-    m_PostInfinity: 2
-    m_RotationOrder: 4
 --- !u!1001 &83790765
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -40522,30 +40394,14 @@ PrefabInstance:
   m_Modification:
     m_TransformParent: {fileID: 0}
     m_Modifications:
-    - target: {fileID: 674811624, guid: f92512e991fcb2f4eb5205899be94ef9, type: 3}
-      propertyPath: m_ApplyToSortingLayers.Array.size
-      value: 4
-      objectReference: {fileID: 0}
-    - target: {fileID: 674811624, guid: f92512e991fcb2f4eb5205899be94ef9, type: 3}
-      propertyPath: m_ApplyToSortingLayers.Array.data[0]
-      value: -1517332431
-      objectReference: {fileID: 0}
-    - target: {fileID: 674811624, guid: f92512e991fcb2f4eb5205899be94ef9, type: 3}
-      propertyPath: m_ApplyToSortingLayers.Array.data[1]
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 674811624, guid: f92512e991fcb2f4eb5205899be94ef9, type: 3}
-      propertyPath: m_ApplyToSortingLayers.Array.data[2]
-      value: -1735733839
-      objectReference: {fileID: 0}
-    - target: {fileID: 674811624, guid: f92512e991fcb2f4eb5205899be94ef9, type: 3}
-      propertyPath: m_ApplyToSortingLayers.Array.data[3]
-      value: -1401224115
-      objectReference: {fileID: 0}
-    - target: {fileID: 6273823577571050653, guid: f92512e991fcb2f4eb5205899be94ef9, type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 1.093
-      objectReference: {fileID: 0}
+    - target: {fileID: 1762368476, guid: f92512e991fcb2f4eb5205899be94ef9, type: 3}
+      propertyPath: handLights.Array.data[0]
+      value: 
+      objectReference: {fileID: 1762368477, guid: f92512e991fcb2f4eb5205899be94ef9, type: 3}
+    - target: {fileID: 1762368476, guid: f92512e991fcb2f4eb5205899be94ef9, type: 3}
+      propertyPath: handLights.Array.data[1]
+      value: 
+      objectReference: {fileID: 1762368478, guid: f92512e991fcb2f4eb5205899be94ef9, type: 3}
     - target: {fileID: 6273823577838093011, guid: f92512e991fcb2f4eb5205899be94ef9, type: 3}
       propertyPath: m_Name
       value: 'Blind '
@@ -40594,52 +40450,11 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 6273823577838093015, guid: f92512e991fcb2f4eb5205899be94ef9, type: 3}
-      propertyPath: footStepAudioSource
-      value: 
-      objectReference: {fileID: 77760973}
-    - target: {fileID: 6273823577838093015, guid: f92512e991fcb2f4eb5205899be94ef9, type: 3}
-      propertyPath: footstepLights.Array.size
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6273823577838093034, guid: f92512e991fcb2f4eb5205899be94ef9, type: 3}
-      propertyPath: m_Controller
-      value: 
-      objectReference: {fileID: 9100000, guid: 1c829553c7199b64a826b8a3587b746c, type: 2}
     - target: {fileID: 6273823577838093038, guid: f92512e991fcb2f4eb5205899be94ef9, type: 3}
       propertyPath: mouth
       value: 
       objectReference: {fileID: 1873421631}
-    - target: {fileID: 6273823577838093039, guid: f92512e991fcb2f4eb5205899be94ef9, type: 3}
-      propertyPath: wallCheckDistance
-      value: 1.16
-      objectReference: {fileID: 0}
-    - target: {fileID: 6273823577838093039, guid: f92512e991fcb2f4eb5205899be94ef9, type: 3}
-      propertyPath: whatIsFloor.m_Bits
-      value: 1088
-      objectReference: {fileID: 0}
-    - target: {fileID: 6273823578461772122, guid: f92512e991fcb2f4eb5205899be94ef9, type: 3}
-      propertyPath: m_Sprite
-      value: 
-      objectReference: {fileID: 21300000, guid: 9aeb1499f133cff4d915edfed789aee7, type: 3}
-    - target: {fileID: 6273823578461772122, guid: f92512e991fcb2f4eb5205899be94ef9, type: 3}
-      propertyPath: m_SortingLayer
-      value: 2
-      objectReference: {fileID: 0}
-    - target: {fileID: 6273823578461772122, guid: f92512e991fcb2f4eb5205899be94ef9, type: 3}
-      propertyPath: m_SortingOrder
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 6273823578461772122, guid: f92512e991fcb2f4eb5205899be94ef9, type: 3}
-      propertyPath: m_SortingLayerID
-      value: -1735733839
-      objectReference: {fileID: 0}
-    m_RemovedComponents:
-    - {fileID: 6273823577838093036, guid: f92512e991fcb2f4eb5205899be94ef9, type: 3}
-    - {fileID: 6273823577838093035, guid: f92512e991fcb2f4eb5205899be94ef9, type: 3}
-    - {fileID: 1762368478, guid: f92512e991fcb2f4eb5205899be94ef9, type: 3}
-    - {fileID: 1762368477, guid: f92512e991fcb2f4eb5205899be94ef9, type: 3}
-    - {fileID: 6273823577838093037, guid: f92512e991fcb2f4eb5205899be94ef9, type: 3}
+    m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: f92512e991fcb2f4eb5205899be94ef9, type: 3}
 --- !u!1001 &1601407740
 PrefabInstance:
@@ -41647,11 +41462,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 7afebb6a01c5e3841bb6fbb8df5d6ae8, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
---- !u!4 &1762368478 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 6273823577838093014, guid: f92512e991fcb2f4eb5205899be94ef9, type: 3}
-  m_PrefabInstance: {fileID: 1579068351}
-  m_PrefabAsset: {fileID: 0}
 --- !u!1 &1771682615
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Scripts/Managers/CameraManager.cs
+++ b/Assets/Scripts/Managers/CameraManager.cs
@@ -62,8 +62,10 @@ public class CameraManager : MonoBehaviour
     {
         input.Disable();
     }
-
-    private void FixedUpdate()
+    
+    //Cuando el player se bajaba de la escalera o cuando terminaba de trepar daba un pantallazo porque el player desaparecia del centro de la pantalla
+    //y la camara se tepeaba al frame siguiente
+    private void LateUpdate()
     {
         var target = isFollowingBlind ? blindCharacter : dogCharacter;
         var pos = target.transform.position;
@@ -82,7 +84,7 @@ public class CameraManager : MonoBehaviour
                 multiplier = -1;
             }
             currentLight.intensity += Time.fixedDeltaTime * timeForFade * multiplier;
-            if((fadeTarget <= currentLight.intensity && multiplier == 1)
+            if ((fadeTarget <= currentLight.intensity && multiplier == 1)
                 || fadeTarget >= currentLight.intensity && multiplier == -1)
             {
                 currentLight.intensity = fadeTarget;

--- a/Assets/Scripts/Player/BasePlayerMovement.cs
+++ b/Assets/Scripts/Player/BasePlayerMovement.cs
@@ -11,8 +11,7 @@ public class BasePlayerMovement : MonoBehaviour
         set { 
             isWalkEnabled = value;
             if (!value)
-            {
-                SetFacingDirection(1);//con esto mira para el mismo lado siempre
+            { //SetFacingDirection sacado de acá porque si se tiene que frenar al player para que trepe no tiene por que mirar siempre en la misma direc
                 anim.SetBool("Running", false); 
             } 
         }
@@ -130,14 +129,11 @@ public class BasePlayerMovement : MonoBehaviour
 
         if (dir!=0)
         {
-
             SetFacingDirection(dir);
-            
         }
-
     }
 
-    private void SetFacingDirection(float dir)
+    public void SetFacingDirection(float dir)
     {
         if (transform.localScale.x != dir)
         {
@@ -145,7 +141,6 @@ public class BasePlayerMovement : MonoBehaviour
             scale.x = dir;
             transform.localScale = scale;
         }
-
     }
 
     public float GetDesiredDir()

--- a/Assets/Scripts/Player/ClimbPlayerMovement.cs
+++ b/Assets/Scripts/Player/ClimbPlayerMovement.cs
@@ -80,9 +80,6 @@ public class ClimbPlayerMovement : MonoBehaviour
             {
                 ledgeDetected = true;
                 ledgePosBot = wallCheck.position;
-
-                print("ledgeDetected");
-
             }
             else
             {

--- a/Assets/Scripts/Player/LadderClimbingPlayerMovement.cs
+++ b/Assets/Scripts/Player/LadderClimbingPlayerMovement.cs
@@ -27,9 +27,9 @@ public class LadderClimbingPlayerMovement : MonoBehaviour
     private Animator anim;
     private BasePlayerMovement basePlayerMovement;
     private float desiredDir;
-
     private bool isClimbingLadder;
 
+    private int leftDirection=1;
 
     #region MonoBehaviour callbacks
     private void Awake()
@@ -40,7 +40,29 @@ public class LadderClimbingPlayerMovement : MonoBehaviour
         basePlayerMovement = GetComponent<BasePlayerMovement>();
         characterLayer= LayerMask.NameToLayer(characterLayerName);
         characterClimbingLayer= LayerMask.NameToLayer(characterClimbingLayerName);
+        input.OnVerticalMovementInput += OnVerticalMovementInput;
     }
+
+    private void FixedUpdate()
+    {
+        if (isClimbingLadder)
+        {
+            var dirDif = desiredDir * climbSpeed - rb.velocity.x;
+            var resultingSpeed = dirDif * acceleration * Time.deltaTime;
+            resultingSpeed = Mathf.Clamp(resultingSpeed, -climbSpeed, climbSpeed);
+            rb.velocity = new Vector2(rb.velocity.x, resultingSpeed);
+
+            if (Mathf.Abs(rb.velocity.x) - 0.1f < 0 || Mathf.Abs(rb.velocity.y) > 0.2f)
+            {
+                ChangeHandStatus(false);
+            }
+            else
+            {
+                ChangeHandStatus(true);
+            }
+        }
+    }
+
     private void OnDestroy()
     {
         input.OnVerticalMovementInput -= OnVerticalMovementInput;
@@ -59,7 +81,7 @@ public class LadderClimbingPlayerMovement : MonoBehaviour
             basePlayerMovement.IsWalkEnabled = false;
             rb.gravityScale = 0;
             isClimbingLadder = true;
-            input.OnVerticalMovementInput += OnVerticalMovementInput;
+            basePlayerMovement.SetFacingDirection(leftDirection);
         }
     }
 
@@ -72,30 +94,7 @@ public class LadderClimbingPlayerMovement : MonoBehaviour
         rb.gravityScale = 1;
         isClimbingLadder = false;
         OnVerticalMovementInput(0);
-        input.OnVerticalMovementInput -= OnVerticalMovementInput;
     }
-
-
-    private void FixedUpdate()
-    {
-        if (isClimbingLadder)
-        {
-            var dirDif = desiredDir * climbSpeed - rb.velocity.x;
-            var resultingSpeed = dirDif * acceleration * Time.deltaTime;
-            resultingSpeed = Mathf.Clamp(resultingSpeed, -climbSpeed, climbSpeed);
-            rb.velocity = new Vector2(rb.velocity.x, resultingSpeed);
-         
-            if (Mathf.Abs(rb.velocity.x) - 0.1f < 0 || Mathf.Abs(rb.velocity.y) > 0.2f)
-            {
-                ChangeHandStatus(false);
-            }
-            else
-            {
-                ChangeHandStatus(true);
-            }
-        }
-    }
-
 
     private void ChangeHandStatus(bool state)
     {
@@ -124,6 +123,4 @@ public class LadderClimbingPlayerMovement : MonoBehaviour
         }
         desiredDir = dir;
     }
-
-
 }

--- a/Assets/Sprites/Characters/BlindAnims/personaje escala prueba.png.meta
+++ b/Assets/Sprites/Characters/BlindAnims/personaje escala prueba.png.meta
@@ -101,6 +101,18 @@ TextureImporter:
     overridden: 0
     androidETC2FallbackOverride: 0
     forceMaximumCompressionQuality_BC6H_BC7: 0
+  - serializedVersion: 3
+    buildTarget: WebGL
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 0
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
   spriteSheet:
     serializedVersion: 2
     sprites:


### PR DESCRIPTION
### Trepado de ciego

Se calculaban medio choto los raycast por como se tomaba la input, entonces los raycast ahora se hacen al tocar espacio

### Subir escalera

Se suscribia y desuscribia el metodo de movimiento vertical, al pedo, porque hay un bool que evita q suba escaleras si no esta subiendo escaleras

### Camara

lo que estaba en fixed lo meti en lateUpdate, porque aveces los pj se movian antes de lo q se actualizaba la camara en el fixed